### PR TITLE
[feature] automate PyPi package publishing with GitHub Actions

### DIFF
--- a/.github/workflows/publish-package-on-release.yaml
+++ b/.github/workflows/publish-package-on-release.yaml
@@ -1,0 +1,25 @@
+name: Publish package
+
+on:
+  release:
+    types: [published]
+    
+jobs:
+  build:
+    name: Publish package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:         
+          python-version: '3.8'
+      - name: Install dependencies
+        run: |
+          pip install poetry poetry-dynamic-versioning
+      - name: Publish package on pypi
+        run: |
+          poetry build
+          poetry publish -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 `lssvr` is a Python module implementing the [Least Squares Support Vector Regression][1] using the scikit-learn as base.
 
+## instalation
+the `lssvr` package is available in [PyPI](https://pypi.org/project/lssvr/). to install, simply type the following command:
+```
+pip install lssvr
+```
+or using [Poetry](python-poetry.org/):
+```
+poetry add lssvr
+```
 
 ## basic usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,5 +26,8 @@ scipy = "^1.5.2"
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=0.12", "poetry-dynamic-versioning"]
 build-backend = "poetry.masonry.api"
+
+[tool.poetry-dynamic-versioning]
+enable = true


### PR DESCRIPTION
Hi @zealberth. I create a workflow to automate the pypi package publishing on a github release. Now, every time you create a release on github, the package will be published in pypi with the release tag. Of course, you have to create an acount on pypi. Another thing you have to do is create two secret variables:
 - `PYPI_USERNAME` : with your pypi username as value
 - `PYPI_PASSWORD`: with your pypi password as value

in short, I made these changes:
 - created a workflow
 - modified the pyprojet file