### PR TITLE
More compliance to sklearn estimator directives

### DIFF
--- a/lssvr/lssvr.py
+++ b/lssvr/lssvr.py
@@ -8,7 +8,7 @@ from scipy.sparse.linalg import lsmr
 
 class LSSVR(BaseEstimator, RegressorMixin):
     """Least Squares Support Vector Regression.
-    
+
     Parameters
     ----------
     C : float, default=2.0
@@ -27,7 +27,7 @@ class LSSVR(BaseEstimator, RegressorMixin):
     ----------
     support_: boolean np.array of shape (n_samples,), default = None
         Array for support vector selection.
-    
+
     alpha_ : array-like
         Weight matrix
 
@@ -54,7 +54,7 @@ class LSSVR(BaseEstimator, RegressorMixin):
 
         support : boolean np.array of shape (n_samples,), default = None
             Array for support vector selection.
-    
+
         Returns
         -------
         self : object
@@ -63,24 +63,23 @@ class LSSVR(BaseEstimator, RegressorMixin):
 
         X, y = check_X_y(X, y, dtype='float')
 
-
         if not support:
             self.support_ = np.ones(X.shape[0], dtype=bool)
         else:
-          self.support_ = check_array(support, ensure_2d=False, dtype='bool')
+            self.support_ = check_array(support, ensure_2d=False, dtype='bool')
 
         self.support_vectors_ = X[self.support_, :]
         support_labels = y[self.support_]
-        
-        self.K_ = self.kernel_func(X, self.support_vectors_) 
+
+        self.K_ = self.kernel_func(X, self.support_vectors_)
         omega = self.K_.copy()
         omega += np.diag(self.support_*1/self.C)
 
         D = np.empty(np.array(omega.shape) + 1)
 
-        D[1:,1:] = omega
+        D[1:, 1:] = omega
         D[0, 1:] = 1
-        D[1:,0 ] = 1
+        D[1:, 0] = 1
 
         shape = np.array(support_labels.shape)
         shape[0] += 1
@@ -88,14 +87,14 @@ class LSSVR(BaseEstimator, RegressorMixin):
 
         t[0] = 0
         t[1:] = support_labels
-    
+
         # TODO: maybe give access to  lsmr atol and btol ?
         try:
             z = lsmr(D.T, t)[0]
         except:
             z = np.linalg.pinv(D).T @ t
 
-        self.bias_  = z[0]
+        self.bias_ = z[0]
         self.alpha_ = z[1:]
         self.alpha_ = self.alpha_[self.support_]
 
@@ -114,7 +113,7 @@ class LSSVR(BaseEstimator, RegressorMixin):
         y : array-like of shape (n_samples,) or (n_samples, n_targets)
             Returns predicted values.
         """
-        
+
         if not hasattr(self, 'support_vectors_'):
             raise NotFittedError
 
@@ -123,20 +122,20 @@ class LSSVR(BaseEstimator, RegressorMixin):
         return (K @ self.alpha_) + self.bias_
 
     def kernel_func(self, u, v):
-        if self.kernel is 'linear':
+        if self.kernel == 'linear':
             return np.dot(u, v.T)
 
-        elif self.kernel is 'rbf':
+        elif self.kernel == 'rbf':
             return rbf_kernel(u, v, gamma=self.gamma)
-            
+
         elif callable(self.kernel):
             if hasattr(self.kernel, 'gamma'):
                 return self.kernel(u, v, gamma=self.gamma)
             else:
                 return self.kernel(u, v)
         else:
-          # default to linear
-          return np.dot(u, v.T)
+            # default to linear
+            return np.dot(u, v.T)
 
     def score(self, X, y):
         from scipy.stats import pearsonr
@@ -144,7 +143,7 @@ class LSSVR(BaseEstimator, RegressorMixin):
         return p ** 2
 
     def norm_weights(self):
-        A = self.alpha_.reshape(-1,1) @ self.alpha_.reshape(-1,1).T
+        A = self.alpha_.reshape(-1, 1) @ self.alpha_.reshape(-1, 1).T
 
-        W = A @ self.K_[self.support_,:]
+        W = A @ self.K_[self.support_, :]
         return np.sqrt(np.sum(np.diag(W)))

--- a/lssvr/lssvr.py
+++ b/lssvr/lssvr.py
@@ -64,18 +64,21 @@ class LSSVR(BaseEstimator, RegressorMixin):
 
         return self
 
-    def predict(self, x_test):
-        K = self.kernel_func(self.kernel, x_test, self.supportVectors, self.gamma)
+    def kernel_func(self, u, v):
+        if self.kernel is 'linear':
+            return np.dot(u, v.T)
 
-        return (K @ self.alphas) + self.bias
-        # return np.sum(K * (np.tile(self.alphas, (K.shape[0], 1))), axis=1) + self.bias
+        elif self.kernel is 'rbf':
+            return rbf_kernel(u, v, gamma=self.gamma)
 
-    def kernel_func(self, kernel, u, v, gamma):
-        if kernel == 'linear':
-            k = np.dot(u, v.T)
-        if kernel == 'rbf':
-            k = rbf_kernel(u, v, gamma=gamma)
-        return k
+        elif callable(self.kernel):
+            if hasattr(self.kernel, 'gamma'):
+                return self.kernel(u, v, gamma=self.gamma)
+            else:
+                return self.kernel(u, v)
+        else:
+          # default to linear
+          return np.dot(u, v.T)
 
     def score(self, X, y):
         from scipy.stats import pearsonr

--- a/lssvr/lssvr.py
+++ b/lssvr/lssvr.py
@@ -1,4 +1,3 @@
-"""Least Squares Support Vector Regression."""
 import numpy as np
 from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.metrics.pairwise import rbf_kernel
@@ -8,9 +7,35 @@ from scipy.sparse import linalg
 
 
 class LSSVR(BaseEstimator, RegressorMixin):
-    def __init__(self, C=2, kernel='linear', gamma=None):
-        self.supportVectors      = None
-        self.supportVectorLabels = None
+    """Least Squares Support Vector Regression.
+    
+    Parameters
+    ----------
+    C : float, default=2.0
+        Regularization parameter. The strength of the regularization is
+        inversely proportional to C. Must be strictly positive.
+
+    kernel : {'linear', 'rbf'}, default='linear'
+        Specifies the kernel type to be used in the algorithm.
+        It must be 'linear', 'rbf' or a callable.
+
+    gamma : float, default = None
+        Kernel coefficient for 'rbf'
+
+
+    Attributes
+    ----------
+    support_: boolean np.array of shape (n_samples,), default = None
+        Array for support vector selection.
+    
+    alpha_ : array-like
+        Weight matrix
+
+    bias_ : array-like
+        Bias vector
+
+
+    """
         self.C = C
         self.gamma = gamma
         self.kernel= kernel
@@ -19,21 +44,23 @@ class LSSVR(BaseEstimator, RegressorMixin):
         self.bias = None 
         self.alphas = None
 
-    def set_params(self, **parameters):
-        for parameter, value in parameters.items():
-            setattr(self, parameter, value)
-        return self
+        """Fit the model according to the given training data.
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            Training data
 
-    def fit(self, x_train, y_train):
-        # self.idxs can be used to select points as support vectors,
-        # so you need another algorithm or criteria to choose them
-        if type(self.idxs) == type(None):
-            self.idxs=np.ones(x_train.shape[0], dtype=bool)
+        y : array-like of shape (n_samples,) or (n_samples, n_targets)
+            Target values.
 
-        self.supportVectors      = x_train[self.idxs, :]
-        self.supportVectorLabels = y_train[self.idxs]
+        support : boolean np.array of shape (n_samples,), default = None
+            Array for support vector selection.
 
-        K = self.kernel_func(self.kernel, x_train, self.supportVectors, self.gamma)
+        Returns
+        -------
+        self : object
+            An instance of the estimator.
+        """
 
         self.K = K
         OMEGA = K
@@ -64,6 +91,18 @@ class LSSVR(BaseEstimator, RegressorMixin):
 
         return self
 
+        """
+        Predict using the estimator.
+        Parameters
+        ----------
+        X : array-like or sparse matrix, shape (n_samples, n_features)
+            Samples.
+
+        Returns
+        -------
+        y : array-like of shape (n_samples,) or (n_samples, n_targets)
+            Returns predicted values.
+        """
     def kernel_func(self, u, v):
         if self.kernel is 'linear':
             return np.dot(u, v.T)

--- a/lssvr/lssvr.py
+++ b/lssvr/lssvr.py
@@ -67,7 +67,7 @@ class LSSVR(BaseEstimator, RegressorMixin):
         if not support:
             self.support_ = np.ones(X.shape[0], dtype=bool)
         else:
-          self.support_ = support
+          self.support_ = check_array(support, ensure_2d=False, dtype='bool')
 
         self.support_vectors_ = X[self.support_, :]
         support_labels = y[self.support_]

--- a/lssvr/lssvr.py
+++ b/lssvr/lssvr.py
@@ -78,6 +78,7 @@ class LSSVR(BaseEstimator, RegressorMixin):
         D = np.empty(np.array(omega.shape) + 1)
 
         D[1:, 1:] = omega
+        D[0, 0] = 0
         D[0, 1:] = 1
         D[1:, 0] = 1
 

--- a/lssvr/lssvr.py
+++ b/lssvr/lssvr.py
@@ -73,7 +73,7 @@ class LSSVR(BaseEstimator, RegressorMixin):
 
         self.K_ = self.kernel_func(X, self.support_vectors_)
         omega = self.K_.copy()
-        omega += np.diag(self.support_*1/self.C)
+        np.fill_diagonal(omega, omega.diagonal()+self.support_/self.C)
 
         D = np.empty(np.array(omega.shape) + 1)
 

--- a/lssvr/lssvr.py
+++ b/lssvr/lssvr.py
@@ -77,15 +77,13 @@ class LSSVR(BaseEstimator, RegressorMixin):
             k = rbf_kernel(u, v, gamma=gamma)
         return k
 
-    def score(self, X, y, sample_weight=None):
+    def score(self, X, y):
         from scipy.stats import pearsonr
         p, _ = pearsonr(y, self.predict(X))
         return p ** 2
 
     def norm_weights(self):
-        n = len(self.supportVectors)
-
-        A = self.alphas.reshape(-1,1) @ self.alphas.reshape(-1,1).T
+        A = self.alpha_.reshape(-1,1) @ self.alpha_.reshape(-1,1).T
 
         W = A @ self.K[self.idxs,:]
         return np.sqrt(np.sum(np.diag(W)))

--- a/lssvr/lssvr.py
+++ b/lssvr/lssvr.py
@@ -61,7 +61,7 @@ class LSSVR(BaseEstimator, RegressorMixin):
             An instance of the estimator.
         """
 
-        X, y = check_X_y(X, y, dtype='float')
+        X, y = check_X_y(X, y, multi_output=True, dtype='float')
 
         if not support:
             self.support_ = np.ones(X.shape[0], dtype=bool)
@@ -118,7 +118,7 @@ class LSSVR(BaseEstimator, RegressorMixin):
         if not hasattr(self, 'support_vectors_'):
             raise NotFittedError
 
-        X = check_array(X)
+        X = check_array(X, ensure_2d=False)
         K = self.kernel_func(X, self.support_vectors_)
         return (K @ self.alpha_) + self.bias_
 


### PR DESCRIPTION
Hello @zealberth! It looks like LSSVR isn't compliant with sklearn directives for estimators compatible with their package as it fails the tests on `sklearn.utils.estimator_checks.check_estimator`. I managed to fix those details, did a little bit of refactoring and also added descriptions for the class and the methods.

Haven't done any tests on data with the modifications I made, but I am feeling confident that the behavior should be the same. Once I confirm that I will report it here.

Let me know what you think!